### PR TITLE
Fix GCS error handling and single bucket handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ async function sendFile(res, bucket, filePath) {
 }
 
 async function handleSingleBucket(req, res) {
-  const filePath = urlPathToFsPath(req.url);
+  const filePath = urlPathToFsPath(req.url.slice(1)/* strip leading `/` */);
   const bucketName = allowedBuckets[0];
 
   if (!bucketRef[bucketName]) {

--- a/index.js
+++ b/index.js
@@ -47,13 +47,11 @@ const handleErrors = fn => async (req, res) => {
   } catch (err) {
     console.log(err.stack);
 
-    if (err.name === "ApiError") {
+    if (err.code === 404) {
       return send(res, 404, notFoundString);
     }
 
-    if (!err.statusCode) {
-      return send(res, 500, internalErrorString);
-    }
+    return send(res, err.code || 500, internalErrorString);
   }
 };
 


### PR DESCRIPTION
This PR fixes 2 bugs:

1. Single bucket mode will always error
   - Root cause: `req.url` contains a leading `/`, causing GCS SDK trying to fetch `<bucket-name>//<rest-of-url>` instead of `<bucket-name>/<rest-of-url>`, causing not-found errors.
   - Note: for multi-bucket mode, the file names is extracted using regexp and does not include the leading `/`, thus no such problem.
2. 404 errors are interpreted as 500
   - Root cause: in this version of Google cloud SDK, `error.name` is not `ApiError` when GCS SDK does not find a file.
   - In this PR I tries to pass through error code provided by the SDK, but does not reveal more information in the client. Devs can still inspect logs to view the full error.